### PR TITLE
Add basic web interface templates

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self';">
+    <title>Configuración del controlador</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Configuración del controlador</h1>
+    </header>
+    <main>
+        <section id="bluetooth">
+            <h2>Inicialización por Bluetooth</h2>
+            <form>
+                <div class="field">
+                    <label for="bt_name">Nombre del dispositivo</label>
+                    <input type="text" id="bt_name" name="bt_name" placeholder="Mi Controlador" autocomplete="off">
+                </div>
+            </form>
+        </section>
+        <section id="network">
+            <h2>Configuración de red</h2>
+            <form>
+                <div class="field">
+                    <label for="ssid">SSID Wi‑Fi</label>
+                    <input type="text" id="ssid" name="ssid" placeholder="Nombre de la red" autocomplete="off">
+                </div>
+                <div class="field">
+                    <label for="wifi_pass">Contraseña Wi‑Fi</label>
+                    <input type="password" id="wifi_pass" name="wifi_pass" placeholder="********">
+                </div>
+                <div class="field">
+                    <label for="ip">Dirección IP</label>
+                    <input type="text" id="ip" name="ip" placeholder="192.168.1.100" pattern="\d{1,3}(\.\d{1,3}){3}">
+                </div>
+                <div class="field">
+                    <label for="gateway">Gateway</label>
+                    <input type="text" id="gateway" name="gateway" placeholder="192.168.1.1" pattern="\d{1,3}(\.\d{1,3}){3}">
+                </div>
+                <div class="field">
+                    <label for="dns">DNS</label>
+                    <input type="text" id="dns" name="dns" placeholder="8.8.8.8" pattern="\d{1,3}(\.\d{1,3}){3}">
+                </div>
+                <button type="submit" disabled>Guardar</button>
+            </form>
+        </section>
+    </main>
+    <footer>
+        <p>Interfaz de demostración sin funciones activas.</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/data/script.js
+++ b/data/script.js
@@ -1,0 +1,2 @@
+// Archivo preparado para futuras funciones de interfaz.
+// Se mantiene vacío para evitar comportamientos inesperados en la configuración.

--- a/data/style.css
+++ b/data/style.css
@@ -1,0 +1,81 @@
+:root {
+    --primary-color: #006d77;
+    --secondary-color: #edf6f9;
+    --accent-color: #83c5be;
+    --danger-color: #e29578;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    background: var(--secondary-color);
+    color: #333;
+    margin: 0;
+}
+
+header, footer {
+    background: var(--primary-color);
+    color: white;
+    padding: 1rem;
+    text-align: center;
+}
+
+main {
+    max-width: 800px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+}
+
+section {
+    background: white;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
+}
+
+label {
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+input {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    padding: 0.7rem 1.2rem;
+    border: none;
+    background: var(--accent-color);
+    color: #fff;
+    border-radius: 4px;
+    font-size: 1rem;
+    cursor: not-allowed;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #1c1c1c;
+        color: #e5e5e5;
+    }
+    section {
+        background: #2d2d2d;
+        box-shadow: none;
+    }
+    input {
+        background: #3a3a3a;
+        color: #e5e5e5;
+        border: 1px solid #555;
+    }
+}


### PR DESCRIPTION
## Summary
- add `data` folder with static HTML/CSS/JS for controller configuration UI
- include responsive styles and placeholders for Bluetooth and network settings

## Testing
- `pio test -e esp32-test` *(fails: HTTPClientError)*

------
https://chatgpt.com/codex/tasks/task_e_68a26a1ff2208326ab09223e904dc049