### PR TITLE
Add microcontroller storage reference JSON

### DIFF
--- a/mc_reference.json
+++ b/mc_reference.json
@@ -1,0 +1,69 @@
+{
+  "device": {
+    "name": "Placa de Reporte Automatico de Tanque",
+    "location": "",
+    "report_interval_minutes": 5
+  },
+  "network": {
+    "wifi": {
+      "ssid": "",
+      "password": "",
+      "mode": "STA",
+      "band": "2.4 GHz",
+      "hidden_ssid": false
+    },
+    "ipv4": {
+      "dhcp": true,
+      "ip": "",
+      "subnet": "",
+      "gateway": "",
+      "dns": ["", ""]
+    },
+    "bluetooth": {
+      "enabled": false,
+      "modes": {
+        "ble": false,
+        "spp": false
+      },
+      "device_name": ""
+    },
+    "profiles": []
+  },
+  "modbus": {
+    "tcp": {
+      "enabled": false,
+      "port": 502
+    },
+    "rtu": {
+      "enabled": false,
+      "baud_rate": 9600,
+      "parity": "none",
+      "stop_bits": 1
+    }
+  },
+  "gateway": {
+    "mapping": [],
+    "monitoring": {
+      "tx_packets": 0,
+      "rx_packets": 0,
+      "errors": 0,
+      "connections": 0,
+      "capture": "off"
+    }
+  },
+  "firmware": {
+    "current_version": "v1.0.0",
+    "target_version": "",
+    "file_url": "",
+    "sha256": "",
+    "auto_reboot": true,
+    "release_notes": "",
+    "history": []
+  },
+  "security": {
+    "admin_user": "admin",
+    "password": "",
+    "https": true,
+    "api_tokens_read_only": false
+  }
+}


### PR DESCRIPTION
## Summary
- add `mc_reference.json` to outline config data intended for microcontroller storage

## Testing
- `node -e "try{JSON.parse(require('fs').readFileSync('mc_reference.json','utf8')); console.log('JSON valid');}catch(e){console.error(e)}"`


------
https://chatgpt.com/codex/tasks/task_e_68a3d8f0d21883268dc7990c482f419f