### PR TITLE
Add custom interrupt-based encoder library

### DIFF
--- a/monitor_velocidad/EncoderInterrupt.cpp
+++ b/monitor_velocidad/EncoderInterrupt.cpp
@@ -1,0 +1,49 @@
+#include "EncoderInterrupt.h"
+
+EncoderInterrupt* EncoderInterrupt::instance_ = nullptr;
+
+EncoderInterrupt::EncoderInterrupt(uint8_t pinA, uint8_t pinB)
+  : pinA_(pinA), pinB_(pinB), position_(0) {}
+
+void EncoderInterrupt::begin() {
+  instance_ = this;
+  pinMode(pinA_, INPUT_PULLUP);
+  pinMode(pinB_, INPUT_PULLUP);
+  attachInterrupt(digitalPinToInterrupt(pinA_), handleA, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(pinB_), handleB, CHANGE);
+}
+
+long EncoderInterrupt::read() const {
+  noInterrupts();
+  long r = position_;
+  interrupts();
+  return r;
+}
+
+void EncoderInterrupt::write(long newPos) {
+  noInterrupts();
+  position_ = newPos;
+  interrupts();
+}
+
+void EncoderInterrupt::update() {
+  bool a = digitalRead(pinA_);
+  bool b = digitalRead(pinB_);
+  if (a == b) {
+    position_++;
+  } else {
+    position_--;
+  }
+}
+
+void EncoderInterrupt::handleA() {
+  if (instance_) {
+    instance_->update();
+  }
+}
+
+void EncoderInterrupt::handleB() {
+  if (instance_) {
+    instance_->update();
+  }
+}

--- a/monitor_velocidad/EncoderInterrupt.h
+++ b/monitor_velocidad/EncoderInterrupt.h
@@ -1,0 +1,24 @@
+#ifndef ENCODER_INTERRUPT_H
+#define ENCODER_INTERRUPT_H
+
+#include <Arduino.h>
+
+class EncoderInterrupt {
+public:
+  EncoderInterrupt(uint8_t pinA, uint8_t pinB);
+  void begin();
+  long read() const;
+  void write(long newPos);
+
+private:
+  uint8_t pinA_;
+  uint8_t pinB_;
+  volatile long position_;
+
+  void update();
+  static EncoderInterrupt* instance_;
+  static void handleA();
+  static void handleB();
+};
+
+#endif

--- a/monitor_velocidad/monitor_velocidad.ino
+++ b/monitor_velocidad/monitor_velocidad.ino
@@ -1,6 +1,6 @@
 #include <SPI.h>
 #include <Ethernet.h>
-#include <Encoder.h>
+#include "EncoderInterrupt.h"
 
 // Configuración de red: ajustar a la red local
 byte mac[] = {0xDE,0xAD,0xBE,0xEF,0xFE,0xED};
@@ -8,7 +8,7 @@ IPAddress ip(192,168,1,177);
 EthernetServer server(80);
 
 // Pines del encoder (usar interrupciones para precisión)
-Encoder encoder(2,3);
+EncoderInterrupt encoder(2,3);
 long lastPosition = 0;
 unsigned long lastTime = 0;
 unsigned long startTime = 0;
@@ -16,6 +16,7 @@ unsigned long startTime = 0;
 void setup(){
   Ethernet.begin(mac, ip);
   server.begin();
+  encoder.begin();
   encoder.write(0);
   lastPosition = 0;
   lastTime = millis();


### PR DESCRIPTION
## Summary
- Replace dependency on external encoder library with custom interrupt-driven implementation
- Integrate new EncoderInterrupt class to handle quadrature signals via hardware interrupts

## Testing
- `curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dcba1c0883269d4d42e806b4727f