### PR TITLE
Add Python speed monitor with real-time plotting

### DIFF
--- a/monitor_velocidad/python_app/README.md
+++ b/monitor_velocidad/python_app/README.md
@@ -1,0 +1,26 @@
+# Speed Monitor Python Application
+
+Esta aplicación Python consulta una placa de medicón de velocidad a través de HTTP y
+muestra los datos en un gráfico en tiempo real.
+
+## Configuración
+
+Modifique el archivo `config.json` para indicar la IP de la placa, el endpoint y el
+intervalo de consulta:
+
+```json
+{
+    "board_ip": "192.168.0.100",
+    "endpoint": "/speed",
+    "poll_interval": 1.0
+}
+```
+
+## Ejecución
+
+```bash
+python3 speed_monitor.py
+```
+
+La aplicación abrirá una ventana de matplotlib con el gráfico de velocidad en
+función del tiempo.

--- a/monitor_velocidad/python_app/config.json
+++ b/monitor_velocidad/python_app/config.json
@@ -1,0 +1,5 @@
+{
+    "board_ip": "192.168.0.100",
+    "endpoint": "/speed",
+    "poll_interval": 1.0
+}

--- a/monitor_velocidad/python_app/requirements.txt
+++ b/monitor_velocidad/python_app/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+requests

--- a/monitor_velocidad/python_app/speed_monitor.py
+++ b/monitor_velocidad/python_app/speed_monitor.py
@@ -1,0 +1,98 @@
+"""Speed monitoring application for corrugator machine.
+
+This script reads speed values from a network connected board and
+plots them in real time using matplotlib. Connection parameters are
+loaded from ``config.json`` in the same directory. The board is
+expected to expose an HTTP endpoint returning JSON data in the
+format::
+
+    {"speed": <value>}
+
+If the board is unreachable or returns invalid data, the graph will
+hold the last valid value. The configuration file also includes the
+polling interval in seconds.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import time
+from collections import deque
+from typing import Deque, Tuple
+
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
+import requests
+
+CONFIG_PATH = pathlib.Path(__file__).with_name("config.json")
+
+
+def load_config() -> Tuple[str, str, float]:
+    """Load configuration from ``config.json``.
+
+    Returns
+    -------
+    tuple
+        A tuple ``(board_ip, endpoint, poll_interval)``.
+    """
+    with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return data["board_ip"], data["endpoint"], float(data.get("poll_interval", 1.0))
+
+
+def fetch_speed(base_url: str) -> float | None:
+    """Fetch the current speed from the board.
+
+    Parameters
+    ----------
+    base_url: str
+        Base URL for the board, e.g. ``"http://192.168.0.100/speed"``.
+
+    Returns
+    -------
+    float | None
+        The speed value if request succeeds, otherwise ``None``.
+    """
+    try:
+        response = requests.get(base_url, timeout=2)
+        response.raise_for_status()
+        payload = response.json()
+        return float(payload["speed"])
+    except Exception:
+        return None
+
+
+def main() -> None:
+    board_ip, endpoint, poll_interval = load_config()
+    base_url = f"http://{board_ip}{endpoint}"
+
+    window: Deque[float] = deque(maxlen=100)
+    times: Deque[float] = deque(maxlen=100)
+
+    fig, ax = plt.subplots()
+    line, = ax.plot([], [], label="Velocidad")
+    ax.set_xlabel("Tiempo (s)")
+    ax.set_ylabel("Velocidad")
+    ax.set_title("Monitor de velocidad")
+    ax.legend(loc="upper right")
+
+    start = time.time()
+
+    def update(_: int) -> Tuple[list[float], list[float]]:
+        value = fetch_speed(base_url)
+        current = time.time() - start
+        if value is not None:
+            window.append(value)
+            times.append(current)
+        line.set_data(list(times), list(window))
+        if times:
+            ax.set_xlim(max(0, times[0]), max(times))
+            ax.set_ylim(min(window) * 0.9, max(window) * 1.1)
+        return line,
+
+    ani = animation.FuncAnimation(fig, update, interval=poll_interval * 1000)
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python real-time speed monitor with matplotlib plot and HTTP polling
- include JSON configuration for board IP and poll interval
- document usage and dependencies

## Testing
- `python -m py_compile monitor_velocidad/python_app/speed_monitor.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a51f8ad978832699a1cdfb6355c496