### PR TITLE
Simplificar monitor de velocidad en python_app_ii

### DIFF
--- a/monitor_velocidad/python_app_ii/README.md
+++ b/monitor_velocidad/python_app_ii/README.md
@@ -1,7 +1,7 @@
 # Speed Monitor Python Application
 
-Esta aplicación Python consulta una placa de medicón de velocidad a través de HTTP y
-muestra los datos en un gráfico en tiempo real.
+Esta aplicación Python consulta una placa de medición de velocidad a través de HTTP y
+muestra en pantalla completa la velocidad, distancia y tiempos sin utilizar gráficos.
 
 ## Configuración
 
@@ -22,5 +22,5 @@ intervalo de consulta:
 python3 speed_monitor.py
 ```
 
-La aplicación abrirá una ventana de matplotlib con el gráfico de velocidad en
-función del tiempo.
+La aplicación abrirá una ventana de matplotlib con los datos en texto grande.
+Si existe un archivo ``logo.png`` en la carpeta se mostrará como logo cuadrado.


### PR DESCRIPTION
## Summary
- Mostrar la velocidad principal en grande y eliminar el gráfico de tiempo
- Distribuir el HUD en una sola fila e incluir un logo cuadrado opcional
- Actualizar README para reflejar la nueva interfaz

## Testing
- `python -m py_compile monitor_velocidad/python_app_ii/speed_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5e83c883c8326a2151b4736e4c734